### PR TITLE
fix(onKeyUp): keys with modifiers should be ignored

### DIFF
--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -841,7 +841,7 @@
   }
 
   function onKeyDown(evt) {
-    if (!_sectionCount || _pause) {
+    if (!_sectionCount || _pause || evt.altKey || evt.ctrlKey || evt.metaKey || evt.shitKey) {
       return;
     }
 
@@ -897,7 +897,7 @@
 
   function onKeyUp(evt) {
     // prevent hijacking shortcuts
-    if (evt.getModifierState()){
+   if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shitKey){
       return
     }
     if (!_pause && _sectionCount && evt.keyCode == 13) {

--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -841,7 +841,8 @@
   }
 
   function onKeyDown(evt) {
-    if (!_sectionCount || _pause || evt.altKey || evt.ctrlKey || evt.metaKey || evt.shitKey) {
+    if (!_sectionCount || _pause || evt.altKey || 
+      evt.ctrlKey || evt.metaKey || evt.shitKey) {
       return;
     }
 
@@ -896,8 +897,7 @@
   }
 
   function onKeyUp(evt) {
-    // prevent hijacking shortcuts
-   if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shitKey){
+    if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shitKey) {
       return
     }
     if (!_pause && _sectionCount && evt.keyCode == 13) {

--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -896,6 +896,10 @@
   }
 
   function onKeyUp(evt) {
+    // prevent hijacking shortcuts
+    if (evt.getModifierState()){
+      return
+    }
     if (!_pause && _sectionCount && evt.keyCode == 13) {
       var currentFocusedElement = getCurrentFocusedElement();
       if (currentFocusedElement && getSectionId(currentFocusedElement)) {


### PR DESCRIPTION
Unless we ignore the modifier keys the lib seems to break various shortcuts. For example in Chrome CMD + Arrow Left/Right doesn't work anymore thus the client is unable to manage the browser history using the keyboard. 
 This commit intends to fix just that.