### PR TITLE
FIX bug for empty selector in getSectionDefaultElement

### DIFF
--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -449,17 +449,21 @@
   }
 
   function parseSelector(selector) {
-    var result;
-    if ($) {
-      result = $(selector).get();
-    } else if (typeof selector === 'string') {
-      result = [].slice.call(document.querySelectorAll(selector));
-    } else if (typeof selector === 'object' && selector.length) {
-      result = [].slice.call(selector);
-    } else if (typeof selector === 'object' && selector.nodeType === 1) {
-      result = [selector];
-    } else {
-      result = [];
+    var result = [];
+    try {
+      if (selector) {
+        if ($) {
+          result = $(selector).get();
+        } else if (typeof selector === 'string') {
+          result = [].slice.call(document.querySelectorAll(selector));
+        } else if (typeof selector === 'object' && selector.length) {
+          result = [].slice.call(selector);
+        } else if (typeof selector === 'object' && selector.nodeType === 1) {
+          result = [selector];
+        }
+      }
+    } catch (err) {
+      console.error(err)
     }
     return result;
   }

--- a/spatial_navigation.js
+++ b/spatial_navigation.js
@@ -463,7 +463,7 @@
         }
       }
     } catch (err) {
-      console.error(err)
+      console.error(err);
     }
     return result;
   }


### PR DESCRIPTION
Hi @luke-chang, 

Your refacto seems to be correct but in case of an empty selector, an error appears : 
```Uncaught DOMException: Failed to execute 'querySelectorAll' on 'Document': The provided selector is empty.```

We just need to check first, like before, if the selector is empty.

Thanks for the refacto ;)
Have a nice day !